### PR TITLE
Option for suppressing cors

### DIFF
--- a/packages/rrweb-snapshot/src/asyncStylesheetManager.ts
+++ b/packages/rrweb-snapshot/src/asyncStylesheetManager.ts
@@ -1,3 +1,4 @@
+import { shouldTryAnonymousFetchingOnCorsError } from './customHelpers';
 import { stringifyStylesheet } from './utils';
 
 //effectively, this becomes the time limit on all fetching (caused by cloning)
@@ -186,6 +187,8 @@ class AsyncStylesheetManager {
     forElement: HTMLLinkElement;
     requestCssId: string;
   }) {
+    if (!shouldTryAnonymousFetchingOnCorsError()) return;
+
     if (this.currentHref != null && document.location.href !== this.currentHref)
       this.blowCache();
 

--- a/packages/rrweb-snapshot/src/customHelpers.ts
+++ b/packages/rrweb-snapshot/src/customHelpers.ts
@@ -1,0 +1,6 @@
+export const shouldTryAnonymousFetchingOnCorsError = () => {
+  return !(
+    '_rrweb_skip_re_fetching_to_suppress_cors_errors' in window &&
+    window._rrweb_skip_re_fetching_to_suppress_cors_errors === true
+  );
+};

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -224,3 +224,9 @@ export type CrossOriginIframeMessageEvent =
   MessageEvent<CrossOriginIframeMessageEventContent>;
 
 export type ErrorHandler = (error: unknown) => void | boolean;
+
+declare global {
+  interface Window {
+    _rrweb_skip_re_fetching_to_suppress_cors_errors?: boolean;
+  }
+}


### PR DESCRIPTION
enabling this option will cause us to not try to fetch resources multiple times if first resource fetching fails (with cross origin anonymous). this is not recommended as it will probably lead to fewer images and stylesheets to load in the replay. but our users can do what they want